### PR TITLE
added support for 9.10+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,12 +27,20 @@ const getVersion = () => {
         .trim()
         .split(".");
 
-      version.length -= 1;
-      version = parseFloat(version.join("."));
+        version.length -= 1;
 
-      if (version < 9.6) {
-        reject("You must have installed MATLAB 2019a or later");
-      }
+        if(version[0].length===1){
+          version[0] = '0'+version[0];
+        }
+        if(version[1].length===1){
+          version[1] = '0'+version[1];
+        }
+        
+        version = parseFloat(version.join(".")).toFixed(2);
+        
+        if (version < 9.06) {
+          reject("You must have installed MATLAB 2019a or later");
+        }
 
       resolve(version);
     });


### PR DESCRIPTION
Simple fix to support versions with 2 digit decimals like 9.10+. should fix #1  